### PR TITLE
Adds quick commands, expands path, and adds "Clear Ids" button

### DIFF
--- a/css/WebDriverTester.css
+++ b/css/WebDriverTester.css
@@ -18,7 +18,7 @@
 }
 
 #path {
-    width: 450px;
+    width: 750px;
 }
 
 .guid-select {

--- a/index.html
+++ b/index.html
@@ -38,21 +38,18 @@
         </div>
     </nav>
 
-
-    <!-- Request Info -->
-    <div class="container">
-        <div class="explanation">
-            <h1>Send a Request</h1>
-            <p class="lead">To send a request to Spartan, specify a port and a command. Modify the command if needed and hit the "Send Request" button.</p>
-        </div>
-    </div><!-- /.container -->
-
     <!-- Request Info Contents -->
     <div class="container">
         <div class="request-info">
             <h2>Request</h2>
+            <p>To send a request to Edge, specify a port and a command. Modify the command if needed and hit the "Send Request" button.</p>
             <p>URL or IP (if left blank will use "http://localhost"): <input id="host" type="text" name="host"></p>
             <p>Port: <input id="port" type="text" name="port" value="17556"></p>
+            <p>Quick commands: 
+                <a onclick="quickCommand('get')">get</a> 
+                <a onclick="quickCommand('findElement')">findElement</a>
+                <a onclick="quickCommand('screenshot')">screenshot</a>
+            </p>
             <p>Command: <select id="commands-select" onchange="updateCommand()"></select></p>
             <p>Method: <select id="methods-select"></select></p>
             <p>Path: <input id="path" type="text"></p>
@@ -70,8 +67,8 @@
                 <br>
             </p>
             <textarea id="content-area"></textarea><br>
-            <p>Sessions <select class="guid-select" id="session-select"></select></p>
-            <p>Elements <select class="guid-select" id="element-select"></select></p>
+            <p>Sessions <select onchange="updateCommand()" class="guid-select" id="session-select"></select></p>
+            <p>Elements <select onchange="updateCommand()" class="guid-select" id="element-select"></select></p>
         </div>
     </div><!-- /.container -->
 
@@ -79,6 +76,8 @@
     <div id="log-div" class="container">
         <h2>Log</h2>  
         <button onclick="clearLog()">Clear Log</button>
+        <button onclick="clearSessionsAndElements()">Clear Ids</button>
+        <button onclick="clearAll()">Clear All</button>
         <div id="log-contents"></div>          
     </div><!-- /.container -->
 

--- a/js/WebDriverTester.js
+++ b/js/WebDriverTester.js
@@ -37,6 +37,13 @@ function setup()
     updateCommand();
 }
 
+function quickCommand(cmd)
+{
+    var strOption = "commands-select-" + cmd;
+    document.getElementById(strOption).selected = true;
+    updateCommand();
+}
+
 function replaceIdsInPath(str, selectType, tokenToReplace) {
     var s = document.getElementById(selectType);
     var index = -1;
@@ -170,6 +177,16 @@ function clearLog() {
     document.getElementById("log-contents").innerHTML = "";
 }
 
+function clearSessionsAndElements() {
+    document.getElementById("session-select").innerHTML = "";
+    document.getElementById("element-select").innerHTML = "";
+}
+
+function clearAll() {
+    clearSessionsAndElements();
+    clearLog();
+}
+
 function addSessionId(sessionId) {
     var o = document.createElement("option");
     o.value = sessionId;
@@ -178,6 +195,7 @@ function addSessionId(sessionId) {
     var s = document.getElementById("session-select");
     s.appendChild(o);
     s.size = s.length;
+    s.selectedIndex = s.length - 1;
 }
 
 function addElementId(elementId) {
@@ -188,6 +206,7 @@ function addElementId(elementId) {
     var s = document.getElementById("element-select");
     s.appendChild(o);
     s.size = s.length;
+    s.selectedIndex = s.length - 1;
 }
 
 function processResponse(xmlhttp) {

--- a/js/common.js
+++ b/js/common.js
@@ -7,7 +7,7 @@ function loadCommands()
     commands = [];
     commands.push({ commandName: "addCookie", method: "POST", path: "/session/SESSION_ID/cookie", requestBody: "{\"cookie\":{\"name\":\"myCookie\", \"value\":\"C is for COOKIE!!\"}}" });
     commands.push({ commandName: "clear", method: "POST", path: "/session/SESSION_ID/element/ELEMENT_ID/clear", requestBody: "" });
-    commands.push({ commandName: "click", method: "POST", path: "/session/SESSION_ID/element/ELEMENT_ID/click", requestBody: "{\"id\":\"ELEMENT_ID\"}" });
+    commands.push({ commandName: "click", method: "POST", path: "/session/SESSION_ID/element/ELEMENT_ID/click", requestBody: "" });
     commands.push({ commandName: "deleteCookie", method: "DELETE", path: "/session/SESSION_ID/cookie/myCookie", requestBody: "" });
     commands.push({ commandName: "deleteCookies", method: "DELETE", path: "/session/SESSION_ID/cookie", requestBody: "" });
     commands.push({ commandName: "executeScript", method: "POST", path: "/session/SESSION_ID/execute", requestBody: "{\"script\": \"return arguments[0].second;\",\"args\": [{\"first\":\"1st\", \"second\":\"2nd\", \"third\":\"3rd\"}]}" });
@@ -15,6 +15,7 @@ function loadCommands()
         requestBody: "{\"script\": \"arguments[1]([ document.getElementsByTagName('div'), 1, 'fancy string', 1.2, {objProp: 3}]);\",\"args\": [{\"first\":\"1st\", \"second\":\"2nd\", \"third\":\"3rd\"}]}" });
     commands.push({ commandName: "findElement", method: "POST", path: "/session/SESSION_ID/element", requestBody: "{\"locator\": \"id\",\"value\": \"clickAnchorElement\"}" });
     commands.push({ commandName: "findElements", method: "POST", path: "/session/SESSION_ID/elements", requestBody: "{\"locator\": \"id\",\"value\": \"clickAnchorElement\"}" });
+    commands.push({ commandName: "get", method: "POST", path: "/session/SESSION_ID/url", requestBody: "{\"url\":\"http://www.bing.com\"}" });
     commands.push({ commandName: "getCapabilities", method: "GET", path: "/session/SESSION_ID", requestBody: "" });
     commands.push({ commandName: "getCookie", method: "GET", path: "/session/SESSION_ID/cookie/myCookie", requestBody: "" });
     commands.push({ commandName: "getCookies", method: "GET", path: "/session/SESSION_ID/cookie", requestBody: "" });
@@ -34,7 +35,6 @@ function loadCommands()
     commands.push({ commandName: "sendKeys", method: "POST", path: "/session/SESSION_ID/element/ELEMENT_ID/value", requestBody: "{\"value\": [\"a\", \"b\", \"c\"]}" });    
     commands.push({ commandName: "sessions", method: "GET", path: "/sessions", requestBody: "" });
     commands.push({ commandName: "status", method: "GET", path: "/status", requestBody: "" });
-    commands.push({ commandName: "url", method: "POST", path: "/session/SESSION_ID/url", requestBody: "{\"url\":\"http://bing.com\"}" });
 }
 
 function getTimeString() {


### PR DESCRIPTION
In addition, removes the "Send a Request" area at the top of the page,
it was taking up too much room. Removes the request body for the click
command since the parameter is in the path, no body is required. Updates the path and the request body when a new sessionId or elementId is selected.
